### PR TITLE
Adjust logo padding

### DIFF
--- a/oc-patches/base-patch/patch.sh
+++ b/oc-patches/base-patch/patch.sh
@@ -76,6 +76,8 @@ echo 'Update web interface JavaScript and overlay image(s)'
 cat "$CURRENT_PATCH_PATH/opencentauri-logo-small.png" > ./app/resources/www/assets/images/network/logo.png
 # Need to re-size logo width from 160px to 300px so it's not to small, since wider!
 sed -re 's|(logo-img\[.+\])\{width:160px\}|\1{width:240px}|' -i ./app/resources/www/*.js
+# Adjust left padding for logo.
+sed -re 's|padding:0 36px 0 145px|padding:0 36px 0 36px|' -i ./app/resources/www/*.js
 # Remove store button
 sed -re 's|(\.store-box\[_ngcontent-%COMP%\])\{cursor:pointer;margin-left:150px;display:flex;align-items:center;border-radius:4px;background:#000;font-family:Microsoft YaHei;padding:6px 10px;font-size:14px;font-weight:400;color:#fff;opacity:.8\}|\1{cursor:pointer;margin-left:150px;display:none;align-items:center;border-radius:4px;background:#000;font-family:Microsoft YaHei;padding:6px 10px;font-size:14px;font-weight:400;color:#fff;opacity:.8}|' -i ./app/resources/www/*.js
 


### PR DESCRIPTION
Subjective, but the stock logo placement always bugged me so here we are.  

Please close if not interested.

Before:

<img width="411" height="187" alt="Screenshot From 2025-10-26 14-14-36" src="https://github.com/user-attachments/assets/7ea924e3-0d96-4774-aeec-da2b13e6984b" />

After:

<img width="411" height="187" alt="Screenshot From 2025-10-26 14-14-04" src="https://github.com/user-attachments/assets/670cfaf1-76b6-43da-818f-402b2b713316" />

