### PR TITLE
Update NTP support in base patchset to be smarter and more reliable

### DIFF
--- a/RESOURCES/OPTIONS/uart/uart.sh
+++ b/RESOURCES/OPTIONS/uart/uart.sh
@@ -6,10 +6,12 @@ if [ $# != 2 ]; then
   exit 1
 fi
 
-check_tools "unzip"
-
 project_root="$1"
 uart_package="$2"
+
+source "$project_root/TOOLS/helpers/utils.sh" "$project_root"
+
+check_tools "unzip"
 
 # check the project root folder
 if [ ! -d "$project_root" ]; then

--- a/oc-patches/base-patch/oc-startntp.sh
+++ b/oc-patches/base-patch/oc-startntp.sh
@@ -1,0 +1,31 @@
+#!/opt/bin/bash
+#
+# Synchronize time to NTP, and every 24 hours!
+#
+#
+if [ $# -eq 1 ]; then
+    OC_NTP_SERVER="$1"
+else
+    OC_NTP_SERVER="pool.ntp.org"
+fi
+
+# Wait a few seconds for wifi to come up before trying the first time
+sleep 5
+
+# Try and sync 
+while [ 1 ]; do
+    echo -n "Attempting to sync initial time... "
+    ntpdate $OC_NTP_SERVER
+    if [ $? -ne 0 ]; then
+        echo "Failed, sleeping and trying again..."
+    else
+        echo "Successful first sync! Starting delay loop..."
+	break
+    fi
+    sleep 1
+done
+
+while [ 1 ]; do
+    sleep 86400
+    /app/ntpdate $OC_NTP_SERVER
+done

--- a/oc-patches/base-patch/oc-startntp.sh
+++ b/oc-patches/base-patch/oc-startntp.sh
@@ -15,7 +15,7 @@ sleep 5
 # Try and sync 
 while [ 1 ]; do
     echo -n "Attempting to sync initial time... "
-    ntpdate $OC_NTP_SERVER
+    /app/ntpdate $OC_NTP_SERVER
     if [ $? -ne 0 ]; then
         echo "Failed, sleeping and trying again..."
     else

--- a/oc-patches/base-patch/patch.sh
+++ b/oc-patches/base-patch/patch.sh
@@ -100,6 +100,8 @@ cat "$CURRENT_PATCH_PATH/wifi-network-config-tool" > ./app/wifi-network-config-t
 chmod 755 ./app/wifi-network-config-tool
 
 echo Installing automatic NTP date/time sync to run on boot
+cat "$CURRENT_PATCH_PATH/oc-startntp.sh" > ./app/oc-startntp.sh
+chmod 755 ./app/oc-startntp.sh
 cat "$CURRENT_PATCH_PATH/ntpdate" > ./app/ntpdate
 chmod 755 ./app/ntpdate
 

--- a/oc-patches/base-patch/rc.local
+++ b/oc-patches/base-patch/rc.local
@@ -23,23 +23,23 @@ if [ -f /opt/etc/entware_release ]; then
   # Mount the USB FAT/exFAT drive if available or if it becomes available
   mount_usb_daemon &
 
-  # Update mlocate db now, and every 24 hours!
-  sh -c "while [ 1 ]; do updatedb; sleep 86400; done" &
-
-  # Synchronize time to NTP, and every 24 hours!
-  sh -c "while [ 1 ]; do /app/ntpdate %OC_NTP_SERVER%; sleep 86400; done" &
-
   # Generate openssh host keys in /opt/etc/ssh (if needed, else it skips)
   ssh-keygen -A
 
   # Start entware system services, includes openssh
   /opt/etc/init.d/rc.unslung start
 
+  # Update mlocate db now, and every 24 hours!
+  sh -c "while [ 1 ]; do updatedb; sleep 86400; done" &
+
   # Start DHCPD for usb0 network interface if available! If not then don't try.
   ifconfig usb0 && udhcpc -i usb0 -b -p /tmp/usb0_udhcpc.pid -s /usr/share/udhcpc/default.script -x hostname:Centauri-Carbon &
 
   # Start wlan0 interface if available
   /app/oc-startwifi.sh
+
+  # Synchronize time to NTP now, and every 24 hours!
+  sh -c "/app/oc-startntp.sh %OC_NTP_SERVER%" &
 fi
 # END: INITIALIZE OpenCentauri and entware
 


### PR DESCRIPTION
The original NTP patch didn't wait until the network was up so performance was intermittent depending on how long that took. Now we try to sync NTP until it is successful, and then go into a sleep period to only sync once a day (like previous behavior).

Also commit a small fix to the uart support (need to source utils.sh as part of running the patch since we're running from the Python patcher), still not enabled by default until we have a new uBoot that works out of the box.