### PR TITLE
noapp.kill added as one-shot app boot prevention

### DIFF
--- a/oc-patches/base-patch/rc.local
+++ b/oc-patches/base-patch/rc.local
@@ -55,3 +55,4 @@ if [ -e /app/noapp.kill ]; then
   echo "/app/noapp.kill deleted."
   exit 0
 fi
+


### PR DESCRIPTION
presence of /app/noapp.kill will prevent the boot of /app/app once and self-clean to help prevent no-boot states